### PR TITLE
0.12 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
    - "0.10"
-
+   - "0.12"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: node_js
 node_js:
    - "0.10"
    - "0.12"
+   - "iojs"

--- a/lib/commands/restart.js
+++ b/lib/commands/restart.js
@@ -1,6 +1,7 @@
 var async = require("async"),
     util = require("util"),
-    cservice = require("../../cluster-service");
+    cservice = require("../../cluster-service"),
+    killWorker = require('../util').killWorker;
 
 module.exports = function(evt, cb, cmd, options) {
   var pid = parseInt(cmd),
@@ -67,15 +68,7 @@ module.exports.more = function(cb) {
 
 function getTask(evt, worker, options, explicitRestart) {
   return function(cb) {
-    // kill new worker if takes too long
-    var newKiller = null;
     var newWorker = null;
-    var exitListener = function() {
-      if (newKiller) {
-        clearTimeout(newKiller);
-      }
-    };
-    var w;
 
     if (worker.cservice.restart === false && explicitRestart === false) {
       cservice.log(
@@ -85,29 +78,29 @@ function getTask(evt, worker, options, explicitRestart) {
       return;
     }
 
+    // kill new worker if takes too long
+    var newKiller = null;
     if (options.timeout > 0) { // start timeout if specified
       newKiller = setTimeout(function() {
-        w = newWorker;
-        newWorker = null;
-        if (w) {
-          w.removeListener("exit", exitListener); // remove temp listener
-          w.kill("SIGKILL"); // go get'em, killer
-        }
-        cb("timed out");
+        killWorker(newWorker, function () {
+          cb("timed out");
+        });
       }, options.timeout);
     }
 
     // lets start new worker
-    newWorker = evt.service.newWorker(worker.cservice, function(err, newWorker){
-      var killer;
-      newWorker.removeListener("exit", exitListener); // remove temp listener
+    newWorker = evt.service.newWorker(worker.cservice, function(err) {
       newWorker = null;
       if (newKiller) { // timeout no longer needed
         clearTimeout(newKiller);
       }
 
+      if (worker.isDead && worker.isDead()) {
+        return void cb();
+      }
+
       // ok, lets stop old worker
-      killer = null;
+      var killer = null;
       if (options.timeout > 0) { // start timeout if specified
         killer = setTimeout(function() {
           worker.kill("SIGKILL"); // go get'em, killer

--- a/lib/commands/shutdown.js
+++ b/lib/commands/shutdown.js
@@ -28,7 +28,9 @@ module.exports = function(evt, cb, cmd, options) {
     exiting = true;
     workersToKill++;
 
-    var timeout = options.timeout > 0 ? setTimeout(getKiller(worker), options.timeout) : null;
+    var timeout =
+      options.timeout > 0
+      && setTimeout(getKiller(worker), options.timeout);
     worker.process.on("exit", getExitHandler(evt, worker, timeout, function() {
       workersToKill--;
       if (workersToKill === 0) {

--- a/lib/commands/shutdown.js
+++ b/lib/commands/shutdown.js
@@ -97,6 +97,7 @@ module.exports.control = function() {
 function getKiller(worker) {
   return function() {
     worker.kill("SIGKILL"); // go get'em, killer
+    worker.process.kill('SIGKILL');
   };
 }
 

--- a/lib/commands/shutdown.js
+++ b/lib/commands/shutdown.js
@@ -28,29 +28,20 @@ module.exports = function(evt, cb, cmd, options) {
     exiting = true;
     workersToKill++;
 
-    worker.process.on(
-      "exit",
-      getExitHandler(
-        evt
-        , worker
-        , options.timeout > 0
-          ? setTimeout(getKiller(worker), options.timeout)
-          : null
-        , function() {
-          workersToKill--;
-          if (workersToKill === 0) {
-            // no workers remain
-            if (evt.service.workers.length === 0) {
-              evt.locals.reason = "kill";
-              cservice.log("All workers shutdown. Exiting...".warn);
-              evt.service.stop(options.timeout, cb);
-            } else {
-              cb(null, "Worker shutdown"); // DONE
-            }
-          }
+    var timeout = options.timeout > 0 ? setTimeout(getKiller(worker), options.timeout) : null;
+    worker.process.on("exit", getExitHandler(evt, worker, timeout, function() {
+      workersToKill--;
+      if (workersToKill === 0) {
+        // no workers remain
+        if (evt.service.workers.length === 0) {
+          evt.locals.reason = "kill";
+          cservice.log("All workers shutdown. Exiting...".warn);
+          evt.service.stop(options.timeout, cb);
+        } else {
+          cb(null, "Worker shutdown"); // DONE
         }
-      )
-    );
+      }
+    }));
     
     require("../workers").exitGracefully(worker);
   });

--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -1,6 +1,7 @@
 var async = require("async"),
   util = require("util"),
-  cservice = require("../../cluster-service");
+  cservice = require("../../cluster-service"),
+  killWorker = require('../util').killWorker;
 
 module.exports = function(evt, cb, workerPath, options) {
   var tasks;
@@ -66,36 +67,25 @@ function getTask(evt, options) {
   return function(cb) {
     // kill new worker if takes too long
     var newKiller = null;
-    var newWorker;
-    var exitListener = function() {
-      if (newKiller) {
-        clearTimeout(newKiller);
-      }
-    };
+    var newWorker = null;
 
     if (options.timeout > 0) { // start timeout if specified
       newKiller = setTimeout(function() {
-        if (!newWorker)
-          return;
-        newWorker.removeListener("exit", exitListener); // remove temp listener
-        newWorker.kill("SIGKILL"); // go get'em, killer
-        cb("timed out");
+        killWorker(newWorker, function() {
+          cb("timed out");
+        });
       }, options.timeout);
       newKiller.unref();
     }
 
     // lets start new worker
-    newWorker = evt.service.newWorker(options, function(err, newWorker) {
-      if (newWorker) { // won't exist if failure
-        newWorker.removeListener("exit", exitListener); // remove temp listener
-      }
+    newWorker = evt.service.newWorker(options, function(err) {
       if (newKiller) { // timeout no longer needed
         clearTimeout(newKiller);
         newKiller = null;
       }
 
       cb(err);
-
     });
   };
 }

--- a/lib/commands/upgrade.js
+++ b/lib/commands/upgrade.js
@@ -1,7 +1,8 @@
 var async = require("async"),
   util = require("util"),
   extend = require("extend"),
-  cservice = require("../../cluster-service");
+  cservice = require("../../cluster-service"),
+  killWorker = require('../util').killWorker;
 
 module.exports = function(evt, cb, cmd, workerPath, options) {
   var pid = parseInt(cmd);
@@ -91,8 +92,7 @@ function getTask(evt, worker, options) {
     if (options.timeout > 0) { // start timeout if specified
       newKiller = setTimeout(function() {
         newWorker.removeListener("exit", exitListener);// remove temp listener
-        newWorker.kill("SIGKILL"); // go get'em, killer
-        cb("timed out");
+        killWorker(newWorker, function () { cb("timed out"); });
       }, options.timeout);
     }
 

--- a/lib/commands/workers.js
+++ b/lib/commands/workers.js
@@ -1,5 +1,4 @@
-var async = require("async"),
-  extend = require("extend");
+var async = require("async");
 
 module.exports = function(evt, cb, cmd) {
   processDetails(evt.service.workers, function(err, workers) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -12,6 +12,7 @@ exports.debug = debug;
 exports.log = log;
 exports.error = error;
 exports.results = results;
+exports.killWorker = killWorker;
 
 function debug() {
   var args;
@@ -200,4 +201,21 @@ function getArgFromValue(val) {
   } catch (ex) {
     return val; // use as-is
   }
+}
+
+function killWorker(worker, cb) {
+  if (worker.isDead && worker.isDead()) {
+    return void cb();
+  }
+
+  function handleExit() {
+    if (cb) {
+      cb();
+      cb = null;
+    }
+  }
+  worker.process.once('exit', handleExit);
+  worker.once('exit', handleExit);
+  worker.kill('SIGKILL');
+  worker.process.kill('SIGKILL');
 }

--- a/lib/workers.js
+++ b/lib/workers.js
@@ -74,7 +74,9 @@ function send(){
 
 function exitGracefully(worker) {
   // inform the worker to exit gracefully
-  if (!worker.isConnected || worker.isConnected()) {
+  if (worker.isConnected && worker.isConnected()) {
     worker.send({ cservice: { cmd: "onWorkerStop" } });
+  } else {
+    worker.process.kill('SIGKILL');
   }
 }

--- a/lib/workers.js
+++ b/lib/workers.js
@@ -74,7 +74,7 @@ function send(){
 
 function exitGracefully(worker) {
   // inform the worker to exit gracefully
-  if (worker.isConnected && worker.isConnected()) {
+  if (!worker.isConnected || worker.isConnected()) {
     worker.send({ cservice: { cmd: "onWorkerStop" } });
   } else {
     worker.process.kill('SIGKILL');

--- a/lib/workers.js
+++ b/lib/workers.js
@@ -13,7 +13,7 @@ function get() {
   var worker;
   for (k in cworkers) {
     worker = cworkers[k];
-    if (!worker.suicide) {
+    if (!worker.suicide && (!worker.isConnected || worker.isConnected())) {
       worker.pid = worker.process.pid;
       workers.push(worker);
     }

--- a/lib/workers.js
+++ b/lib/workers.js
@@ -13,13 +13,11 @@ function get() {
   var worker;
   for (k in cworkers) {
     worker = cworkers[k];
-    if (!worker.suicide && (!worker.isConnected || worker.isConnected())) {
-      worker.pid = worker.process.pid;
-      workers.push(worker);
-    }
+    worker.pid = worker.process.pid;
+    workers.push(worker);
   }
 
-  workers.send=send;
+  workers.send = send;
 
   return workers;
 }
@@ -70,7 +68,7 @@ function monitor() {
  */
 function send(){
   this.forEach(function(worker){
-    //worker.send.apply(worker, [].slice.apply(arguments));
+    worker.send.apply(worker, [].slice.apply(arguments));
   });
 }
 

--- a/lib/workers.js
+++ b/lib/workers.js
@@ -13,8 +13,10 @@ function get() {
   var worker;
   for (k in cworkers) {
     worker = cworkers[k];
-    worker.pid = worker.process.pid;
-    workers.push(worker);
+    if (!worker.suicide) {
+      worker.pid = worker.process.pid;
+      workers.push(worker);
+    }
   }
 
   workers.send=send;
@@ -74,5 +76,7 @@ function send(){
 
 function exitGracefully(worker) {
   // inform the worker to exit gracefully
-  worker.send({cservice: {cmd: "onWorkerStop"}});
+  if (!worker.isConnected || worker.isConnected()) {
+    worker.send({ cservice: { cmd: "onWorkerStop" } });
+  }
 }

--- a/test/start-restart.js
+++ b/test/start-restart.js
@@ -70,8 +70,8 @@ if(cservice.isWorker){
         setTimeout(function() {
           assert.equal(
             cservice.workers.length,
-            2,
-            "2 workers expected, but " + cservice.workers.length + " found"
+            1,
+            "1 worker expected, but " + cservice.workers.length + " found"
           );
           done();
         }, 1000);

--- a/test/start-restart.js
+++ b/test/start-restart.js
@@ -64,19 +64,18 @@ if(cservice.isWorker){
       );
     });
 
-    it('Restart with timeout', function(done) {
+    // Skipping until requirements are cleared up
+    it.skip('Restart with timeout', function(done) {
       cservice.trigger("restart", function(err) {
         assert.equal(err, "timed out");
         setTimeout(function() {
           assert.equal(
             cservice.workers.length,
-            1,
-            "1 worker expected, but " + cservice.workers.length + " found"
-          );
+            2,
+            "2 workers expected, but " + cservice.workers.length + " found");
           done();
         }, 1000);
-      }, "all", {timeout: 1} // with timeout
-      );
+      }, "all", {timeout: 1});  // with timeout
     });
 
     it('Stop workers', function(done) {

--- a/test/start-restart.js
+++ b/test/start-restart.js
@@ -65,7 +65,7 @@ if(cservice.isWorker){
     });
 
     // Skipping until requirements are cleared up
-    it.skip('Restart with timeout', function(done) {
+    it('Restart with timeout', function(done) {
       cservice.trigger("restart", function(err) {
         assert.equal(err, "timed out");
         setTimeout(function() {

--- a/test/start-stop.js
+++ b/test/start-stop.js
@@ -8,6 +8,8 @@ if(cservice.isWorker){
   it("WORKER", function(done) {});
 } else {
   describe('[Start & Stop]', function() {
+    this.timeout(10000);
+
     it('Start worker', function(done) {
       assert.equal(
         cservice.workers.length,
@@ -71,15 +73,18 @@ if(cservice.isWorker){
         assert.equal(
           cservice.workers.length,
           2,
-          "2 workers expected, but " + cservice.workers.length + " found"
-        );
+          "2 workers expected, but " + cservice.workers.length + " found");
         done();
       }, "./test/workers/basic", {count: 1, timeout: 10000});
     });
 
     it('Timeout on new worker', function(done) {
-      cservice.trigger("start", function(err, result) {
+      cservice.trigger("start", function(err) {
         assert.equal(err, "timed out");
+        assert.equal(
+          cservice.workers.length,
+          2,
+          "2 workers expected, but " + cservice.workers.length + " found");
         done();
       }, "./test/workers/longInit", {count: 1, timeout: 100});
     });
@@ -88,8 +93,11 @@ if(cservice.isWorker){
       cservice.trigger("help", function(err, result) {
         assert.equal(
           result.info,
-          "Gracefully start service, one worker at a time."
-        );
+          "Gracefully start service, one worker at a time.");
+        assert.equal(
+          cservice.workers.length,
+          2,
+          "2 workers expected, but " + cservice.workers.length + " found");
         done();
       }, "start");
     });
@@ -97,6 +105,10 @@ if(cservice.isWorker){
     it('Bad worker start', function(done) {
       cservice.trigger("start", function(err, result) {
         assert.equal(err, "Invalid request. Try help start");
+        assert.equal(
+          cservice.workers.length,
+          2,
+          "2 workers expected, but " + cservice.workers.length + " found");
         done();
       }, null, {count: 1, timeout: 1000});
     });
@@ -109,8 +121,7 @@ if(cservice.isWorker){
           "2 workers expected, but " + cservice.workers.length + " found"
         );
         done();
-      }, "all"
-        );
+      }, "all");
     });
 
     it('Upgrade workers', function(done) {


### PR DESCRIPTION
Fixed tests so they pass using Node 0.12. The breakage stems from the fact that Node 0.12 lists workers in `cluster.workers` that are in process of suicide or have closed their IPC channel with the master. Added code to check for these conditions if 0.12 artifacts are present.